### PR TITLE
test(jarvis): minimal deterministic contract test for /jarvis/api/verify/status

### DIFF
--- a/services/assistance/jarvis-backend/test_verify_status.py
+++ b/services/assistance/jarvis-backend/test_verify_status.py
@@ -1,0 +1,31 @@
+import pytest
+from fastapi.testclient import TestClient
+
+import main
+
+
+async def _stub_debug_status() -> dict:
+    return {"ok": True, "checks": []}
+
+
+async def _stub_verify_frontend_bundle(base_url: str, *, timeout_s: float = 6.0) -> dict:
+    return {"name": "jarvis-frontend", "ok": True, "markers": {}}
+
+
+def test_verify_status_contract(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(main, "debug_status", _stub_debug_status)
+    monkeypatch.setattr(main, "_verify_frontend_bundle", _stub_verify_frontend_bundle)
+
+    client = TestClient(main.app)
+    res = client.get("/jarvis/api/verify/status")
+
+    assert res.status_code == 200
+    data = res.json()
+    assert isinstance(data, dict)
+    assert isinstance(data["ok"], bool)
+    assert isinstance(data["checks"], list)
+
+    names = {c["name"] for c in data["checks"] if isinstance(c, dict)}
+    assert "jarvis-backend" in names
+    assert "jarvis-backend-debug-status" in names
+    assert "jarvis-frontend" in names

--- a/services/assistance/jarvis-backend/test_verify_status.py
+++ b/services/assistance/jarvis-backend/test_verify_status.py
@@ -15,6 +15,7 @@ async def _stub_verify_frontend_bundle(base_url: str, *, timeout_s: float = 6.0)
 def test_verify_status_contract(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(main, "debug_status", _stub_debug_status)
     monkeypatch.setattr(main, "_verify_frontend_bundle", _stub_verify_frontend_bundle)
+    monkeypatch.setattr(main, "feature_enabled", lambda _name: True)
 
     client = TestClient(main.app)
     res = client.get("/jarvis/api/verify/status")


### PR DESCRIPTION
Replaces polluted PR #193 (was based on main) with a clean diff based on idc1-assistance.

- Adds minimal contract test for /jarvis/api/verify/status
- Monkeypatches debug_status + _verify_frontend_bundle to avoid network
- Monkeypatches feature_enabled to ensure determinism

After merge, we should close #193.