### PR TITLE
docs(jarvis): document /jarvis/api/verify/status

### DIFF
--- a/services/assistance/docs/OVERVIEW.md
+++ b/services/assistance/docs/OVERVIEW.md
@@ -41,6 +41,7 @@ graph TD
 - Build/deploy (SSOT): `services/assistance/docs/BUILD.md`
 - System notes: `services/assistance/docs/SYSTEM.md`
 - WS protocol/tools: `services/assistance/docs/TOOLS.md`
+- Operator verification endpoint: `services/assistance/docs/verify-status.md`
 
 ## Conventions
 

--- a/services/assistance/docs/verify-status.md
+++ b/services/assistance/docs/verify-status.md
@@ -1,0 +1,75 @@
+# Operator Verification: `/jarvis/api/verify/status`
+
+A read-only endpoint for operators to confirm that the Jarvis stack is healthy and correctly wired end-to-end.
+
+## Endpoint
+
+```
+GET /jarvis/api/verify/status
+```
+
+Accessible locally via:
+
+```bash
+curl -s http://127.0.0.1:18018/jarvis/api/verify/status | jq .
+```
+
+Or through the host reverse proxy:
+
+```bash
+curl -s https://<host>/jarvis/api/verify/status | jq .
+```
+
+## What it checks
+
+| Check name | What it does |
+|---|---|
+| `jarvis-backend` | Calls `/health` on the backend and asserts `ok: true` |
+| `jarvis-backend-debug-status` | Calls `/jarvis/api/debug/status` and asserts `ok: true` |
+| `jarvis-frontend` | Resolves the frontend's bundled JS asset URL and checks it for required bundle markers |
+
+## Response shape
+
+The `checks` field is a **list** of objects, one per sub-check. The top-level `ok` is `true` only when every sub-check passes.
+
+```json
+{
+  "ok": true,
+  "checks": [
+    {"name": "jarvis-backend",              "ok": true, "details": {"git_sha": "abc1234", "uptime_seconds": 3600}},
+    {"name": "jarvis-backend-debug-status", "ok": true, "details": {"status": "ok"}},
+    {"name": "jarvis-frontend",             "ok": true,
+      "url": "https://assistance.idc1.surf-thailand.com/jarvis/assets/index-Abc123.js",
+      "is_html": false,
+      "markers": {
+        "jarvis_status_details_open": true,
+        "/jarvis/api/debug/status": true,
+        "Hide status details": true
+      }
+    }
+  ]
+}
+```
+
+### Failure modes
+
+| Symptom | Meaning |
+|---|---|
+| `"skipped": true, "error": "not_configured"` in a check entry | The env var needed for that sub-check is not set — the check is skipped rather than failing hard |
+| `"is_html": true` in the `jarvis-frontend` check | The resolved bundle URL returned an HTML document instead of JS; typically a SPA fallback / Caddy routing misconfiguration |
+
+## Environment variables (stack compose)
+
+Both variables are wired in `stacks/idc1-assistance/docker-compose.yml`.
+
+| Variable | Default in compose | Purpose |
+|---|---|---|
+| `JARVIS_PUBLIC_BASE_URL` | `https://assistance.idc1.surf-thailand.com` | Public Jarvis *frontend* base URL used by the frontend bundle-marker verification (fallback when `JARVIS_VERIFY_FRONTEND_BASE_URL` is unset). |
+| `JARVIS_VERIFY_FRONTEND_BASE_URL` | _(empty — optional)_ | Override the frontend root URL used for the bundle marker check. When unset the endpoint falls back to `JARVIS_PUBLIC_BASE_URL`. |
+
+To override for a non-standard deployment, add the variable to `stacks/idc1-assistance/.env`:
+
+```dotenv
+JARVIS_PUBLIC_BASE_URL=http://127.0.0.1:18018
+JARVIS_VERIFY_FRONTEND_BASE_URL=http://127.0.0.1:18080
+```


### PR DESCRIPTION
Clean replacement for polluted/closed PR #194 (which was based on main).

- Adds operator doc: services/assistance/docs/verify-status.md
- Adds discoverability link from services/assistance/docs/OVERVIEW.md

Notes:
- Does not change stack compose defaults.
- Documents frontend bundle markers used by verification.