### PR TITLE
docs(assistance): document Skills Sheet SSOT routing — schema, tools, and operator flow

### DIFF
--- a/services/assistance/README.md
+++ b/services/assistance/README.md
@@ -1,0 +1,13 @@
+# Assistance Service (Jarvis)
+
+Real-time conversational backend bridging WebSocket clients to Gemini Live.
+
+## Documentation
+
+| Doc | Contents |
+|-----|----------|
+| [docs/OVERVIEW.md](docs/OVERVIEW.md) | Architecture diagram, routing layers, key concepts |
+| [docs/SYSTEM.md](docs/SYSTEM.md) | Skills Sheet schema, `sys_kv` keys, routing configuration |
+| [docs/TOOLS.md](docs/TOOLS.md) | Deterministic tool reference (`system_skills_list`, `system_skill_get`, …) |
+| [docs/ACTION.md](docs/ACTION.md) | Operator runbook: update sheet → reload → verify |
+| [docs/CHARTS.md](docs/CHARTS.md) | Diagram notes |

--- a/services/assistance/docs/ACTION.md
+++ b/services/assistance/docs/ACTION.md
@@ -1,0 +1,103 @@
+# Assistance Service — Operator Actions
+
+Step-by-step procedures for managing Skills Sheet routing.  
+For background and schema, see [SYSTEM.md](SYSTEM.md).
+
+---
+
+## Prerequisites
+
+- Access to the Skills Sheet (identified by `system.skills.sheet_name` in `sys_kv`)
+- Operator access to the Jarvis admin UI or API
+
+---
+
+## Update the Skills Sheet
+
+1. Open the Skills Sheet identified by the current value of `system.skills.sheet_name`.
+2. Edit or add rows following the schema in [SYSTEM.md — Skill row schema](SYSTEM.md#skill-row-schema).
+3. Key rules:
+   - `name` must be unique across all rows.
+   - Set `enabled = false` to disable a row without deleting it.
+   - Set `match_type = none` for inject-only rows (they have no runtime pattern).
+   - `arg_json` must be valid JSON or left blank.
+
+---
+
+## Apply: System Reload
+
+After saving sheet changes, trigger a reload so the backend picks them up:
+
+**Option A — UI**
+1. Navigate to **Settings → System → Reload**.
+2. Confirm the reload prompt.
+3. Wait for the success toast / status indicator.
+
+**Option B — API**
+```bash
+curl -X POST http://127.0.0.1:18018/jarvis/api/system/reload
+```
+
+Expected response:
+```json
+{ "ok": true, "reloaded_at": "2026-03-27T05:00:00Z" }
+```
+
+> A reload does **not** restart the WebSocket session; active clients reconnect automatically.
+
+---
+
+## Verify
+
+### 1. List loaded skills
+
+```
+/tool system_skills_list {}
+```
+
+Check the response:
+- `ok` is `true`
+- `sheet_name` matches `system.skills.sheet_name`
+- `routing_enabled` matches `system.skills.routing.enabled`
+- Expected rows appear in the `skills` array with correct `enabled` values
+
+See [TOOLS.md — system_skills_list](TOOLS.md#system_skills_list) for the full response shape.
+
+### 2. Fetch a specific skill
+
+```
+/tool system_skill_get { "name": "<skill-name>" }
+```
+
+Confirm the row fields match what was saved in the sheet.
+
+### 3. Check the compat voice-commands endpoint
+
+```bash
+curl http://127.0.0.1:18018/config/voice_commands
+```
+
+The response is a backward-compatible representation derived from skill rows with a non-`none` `match_type`.  
+Use this to confirm routing patterns are visible to older clients.
+
+---
+
+## Enable / Disable Sheet-First Routing
+
+| Goal | Action |
+|------|--------|
+| Enable sheet-first routing | Set `system.skills.routing.enabled = true` in `sys_kv`, then reload |
+| Disable (legacy fallback) | Set `system.skills.routing.enabled = false` in `sys_kv`, then reload |
+| Change the active sheet | Update `system.skills.sheet_name` in `sys_kv`, then reload |
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| `system_skills_list` returns empty `skills` | `sheet_name` not set or sheet unreachable | Check `system.skills.sheet_name` in `sys_kv`; confirm sheet exists |
+| Routing not triggering despite `routing_enabled: true` | Pattern mismatch | Check `match_type` and `pattern`; test with `exact` before switching to `regex` |
+| `routing_enabled` is `false` | Key not set or explicitly disabled | Set `system.skills.routing.enabled = true` and reload |
+| `/config/voice_commands` returns empty list | No rows with non-`none` `match_type` are enabled | Enable at least one routing row in the sheet |
+| Reload returns non-`ok` | Backend error loading sheet | Check backend logs; verify sheet format and `sheet_name` value |

--- a/services/assistance/docs/OVERVIEW.md
+++ b/services/assistance/docs/OVERVIEW.md
@@ -1,0 +1,82 @@
+# Assistance Service — Overview
+
+The assistance service (Jarvis) is the real-time conversational backend.  
+It bridges WebSocket clients to Gemini Live and manages the complete request lifecycle, including skill routing, tool dispatch, and system-instruction assembly.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph Client ["Client to Backend"]
+        WS_TEXT["WS text frame"]
+        WS_AUDIO["WS audio frame"]
+    end
+
+    subgraph Backend ["Backend (Jarvis)"]
+        ROUTER["Skill Router\n(sheet-first)"]
+        GEMINI["Gemini Live session"]
+        TOOL_DISP["Tool Dispatcher"]
+        SYS_INST["System Instruction Builder\n(skills injection)"]
+    end
+
+    subgraph Sheet ["Skills Sheet (SSOT)"]
+        SHEET_ROW["name · enabled · priority\nmatch_type · pattern · lang\nhandler · arg_json"]
+    end
+
+    subgraph KV ["sys_kv"]
+        KV_SHEET["system.skills.sheet_name"]
+        KV_ROUTING["system.skills.routing.enabled"]
+    end
+
+    subgraph Client2 ["Backend to Client"]
+        WS_RESP["WS response frame"]
+    end
+
+    WS_TEXT -->|transcript| ROUTER
+    WS_AUDIO -->|transcript| ROUTER
+    ROUTER -->|skill match| TOOL_DISP
+    ROUTER -->|no match / fallback| GEMINI
+    GEMINI -->|model tool call| TOOL_DISP
+    GEMINI -->|text/audio output| WS_RESP
+    TOOL_DISP -->|result| WS_RESP
+    SYS_INST -->|injected content| GEMINI
+    SHEET_ROW --> ROUTER
+    SHEET_ROW --> SYS_INST
+    KV_SHEET --> SHEET_ROW
+    KV_ROUTING --> ROUTER
+```
+
+## Routing Layers (in order)
+
+| Layer | Trigger | Description |
+|-------|---------|-------------|
+| **Sheet-first routing** | Input transcript matches a skill row `pattern` | Deterministic; bypasses Gemini for matched intents |
+| **Gemini Live model** | Transcript forwarded when no sheet match | Gemini may emit a model tool call |
+| **Legacy fallback** | `system.skills.routing.enabled = false` | Pre-sheet behaviour; all transcripts go straight to Gemini |
+
+> Sheet-first routing is active only when `system.skills.routing.enabled` is `true` and a valid `system.skills.sheet_name` is set.
+
+## Key Concepts
+
+### Skills Sheet
+A spreadsheet (or equivalent data source) identified by `system.skills.sheet_name` in `sys_kv`.  
+Each row defines one skill — see [SYSTEM.md](SYSTEM.md) for the full schema.
+
+### Skill injection into system instruction
+At session start, enabled skill rows with `handler = inject` have their content folded into the effective system instruction in priority order.  This is a separate concern from routing; the same sheet drives both.
+
+### Deterministic tool calls
+Two observability tools are always available regardless of model state:
+- `system_skills_list` — list all loaded skill rows and their status
+- `system_skill_get { "name": "<name>" }` — fetch a single skill row
+
+See [TOOLS.md](TOOLS.md) for the full tool reference.
+
+## Operator Quick Links
+
+| Task | Where |
+|------|-------|
+| Update skill rows | [SYSTEM.md — Skill row schema](SYSTEM.md#skill-row-schema) |
+| Apply changes (reload) | [ACTION.md — Apply](ACTION.md#apply-system-reload) |
+| Verify routing | [ACTION.md — Verify](ACTION.md#verify) |
+| Full runbook | [ACTION.md](ACTION.md) |

--- a/services/assistance/docs/SYSTEM.md
+++ b/services/assistance/docs/SYSTEM.md
@@ -1,0 +1,89 @@
+# Assistance Service — System Configuration
+
+Reference for Skills Sheet schema, `sys_kv` keys, and routing configuration.
+
+## Skills Sheet
+
+The Skills Sheet is the **single source of truth (SSOT)** for both skill routing and system-instruction injection.  
+The sheet to load is identified by the `system.skills.sheet_name` key in `sys_kv`.
+
+### Skill row schema
+
+| Column | Type | Required | Description |
+|--------|------|----------|-------------|
+| `name` | string | ✓ | Unique identifier for the skill (e.g. `weather_lookup`) |
+| `enabled` | boolean | ✓ | `true` to activate this row; `false` to skip silently |
+| `priority` | integer | ✓ | Lower number = higher priority; used for tie-breaking and injection order |
+| `match_type` | enum | — | How `pattern` is evaluated: `exact`, `prefix`, `regex`, or `none` (inject-only) |
+| `pattern` | string | — | Transcript pattern to match against (interpreted per `match_type`) |
+| `lang` | string | — | BCP-47 language tag for pattern matching (e.g. `th`, `en`); leave blank to match any |
+| `handler` | enum | ✓ | What to do on match: `tool_call`, `inject`, or `passthrough` |
+| `arg_json` | JSON string | — | Arguments forwarded to the handler (for `tool_call` rows: the tool name and fixed args) |
+
+#### `handler` values
+
+| Value | Behaviour |
+|-------|-----------|
+| `tool_call` | Executes the tool named in `arg_json.tool` with `arg_json.args` merged with any runtime args |
+| `inject` | Folds the skill content into the system instruction at session start (routing not triggered at runtime) |
+| `passthrough` | Matches but forwards the transcript to Gemini Live unchanged (useful for tagging without acting) |
+
+#### `match_type` values
+
+| Value | Behaviour |
+|-------|-----------|
+| `exact` | Case-folded exact string match |
+| `prefix` | Transcript starts with `pattern` (after trimming) |
+| `regex` | Full ECMAScript regex match against the transcript |
+| `none` | Row is never matched at runtime (inject-only rows use this) |
+
+### Example rows
+
+```
+name                  enabled  priority  match_type  pattern         lang  handler    arg_json
+--------------------  -------  --------  ----------  --------------- ----  ---------  -----------------------------------------
+weather_lookup        true     10        prefix      อากาศ           th    tool_call  {"tool":"get_weather","args":{}}
+time_now              true     10        exact       what time is it  en   tool_call  {"tool":"time_now","args":{}}
+live_api_best_prac    true     50        none                               inject     {}
+```
+
+---
+
+## sys_kv Keys
+
+`sys_kv` is the key-value store used to configure runtime behaviour without redeploy.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `system.skills.sheet_name` | string | _(none)_ | Name / ID of the Skills Sheet to load. Required for routing and injection to be active |
+| `system.skills.routing.enabled` | boolean | `false` | Set to `true` to enable sheet-first routing. When `false`, all transcripts go directly to Gemini Live (legacy behaviour) |
+
+### Setting a key
+
+Use the operator UI or equivalent API:
+
+```
+POST /sys_kv/set
+{ "key": "system.skills.routing.enabled", "value": true }
+```
+
+---
+
+## Routing Behaviour Reference
+
+| `routing.enabled` | `sheet_name` set | Effect |
+|-------------------|-----------------|--------|
+| `false` | any | Legacy mode — all transcripts sent to Gemini Live |
+| `true` | _(none)_ | Routing enabled but no sheet loaded — falls through to Gemini Live |
+| `true` | set | **Sheet-first routing active** — matched rows dispatched, unmatched fall through to Gemini Live |
+
+---
+
+## Compat: `/config/voice_commands`
+
+`GET /config/voice_commands` returns a backward-compatible representation of routing rows for clients that pre-date the Skills Sheet.  
+The skills sheet is the authoritative source; this endpoint derives its output from enabled rows with a non-`none` `match_type`.
+
+---
+
+For the full operator procedure see [ACTION.md](ACTION.md).

--- a/services/assistance/docs/TOOLS.md
+++ b/services/assistance/docs/TOOLS.md
@@ -1,0 +1,157 @@
+# Assistance Service — Tool Reference
+
+Deterministic tools exposed by the assistance service.  
+These tools are always available regardless of the active Gemini Live model state.
+
+## Skills tools
+
+### `system_skills_list`
+
+Returns all skill rows currently loaded from the active Skills Sheet, with their resolved status.
+
+**Request**
+```json
+{}
+```
+
+**Response**
+```json
+{
+  "ok": true,
+  "skills": [
+    {
+      "name": "weather_lookup",
+      "enabled": true,
+      "priority": 10,
+      "match_type": "prefix",
+      "pattern": "อากาศ",
+      "lang": "th",
+      "handler": "tool_call",
+      "arg_json": { "tool": "get_weather", "args": {} }
+    },
+    {
+      "name": "live_api_best_prac",
+      "enabled": true,
+      "priority": 50,
+      "match_type": "none",
+      "pattern": "",
+      "lang": "",
+      "handler": "inject",
+      "arg_json": {}
+    }
+  ],
+  "routing_enabled": true,
+  "sheet_name": "jarvis-skills-prod"
+}
+```
+
+**Use case:** Verify which skills are active after a sheet update or reload.  
+See [ACTION.md — Verify](ACTION.md#verify).
+
+---
+
+### `system_skill_get`
+
+Fetches a single skill row by name.
+
+**Request**
+```json
+{ "name": "weather_lookup" }
+```
+
+**Response**
+```json
+{
+  "ok": true,
+  "skill": {
+    "name": "weather_lookup",
+    "enabled": true,
+    "priority": 10,
+    "match_type": "prefix",
+    "pattern": "อากาศ",
+    "lang": "th",
+    "handler": "tool_call",
+    "arg_json": { "tool": "get_weather", "args": {} }
+  }
+}
+```
+
+**Error response (not found)**
+```json
+{ "ok": false, "error": "skill not found", "name": "weather_lookup" }
+```
+
+---
+
+## System tools
+
+### `system_macros_list`
+
+Returns all loaded macro rows with their enabled state.
+
+**Request**
+```json
+{}
+```
+
+**Response**
+```json
+{
+  "ok": true,
+  "macros": [
+    { "name": "macro_what_time", "enabled": true }
+  ]
+}
+```
+
+---
+
+### `system_run_macro`
+
+Executes a named macro.
+
+**Request**
+```json
+{ "name": "macro_what_time", "args": {} }
+```
+
+**Response**
+```json
+{ "ok": true, "result": "..." }
+```
+
+---
+
+### `time_now`
+
+Returns the current server time and the active instance identifier.
+
+**Request**
+```json
+{}
+```
+
+**Response**
+```json
+{ "ok": true, "time": "2026-03-27T05:00:00Z", "instance_id": "jarvis-prod-01" }
+```
+
+---
+
+## Tool invocation patterns
+
+Tools can be invoked in three ways:
+
+| Method | Example |
+|--------|---------|
+| Direct WS message | `/tool system_skills_list {}` |
+| Gemini model tool call | Model emits a `functionCall` that the dispatcher resolves |
+| HTTP (debug only) | `POST /jarvis/api/tool/invoke` `{ "name": "system_skills_list", "args": {} }` |
+
+---
+
+## Related
+
+- [SYSTEM.md](SYSTEM.md) — Skills Sheet schema and sys_kv keys
+- [OVERVIEW.md](OVERVIEW.md) — Routing architecture diagram
+- [ACTION.md](ACTION.md) — Operator procedures (update → reload → verify)


### PR DESCRIPTION
Replaces closed PR #186 (accidentally closed).

Adds SSOT Skills Sheet docs:
- services/assistance/docs/OVERVIEW.md
- services/assistance/docs/SYSTEM.md
- services/assistance/docs/TOOLS.md
- services/assistance/docs/ACTION.md
- services/assistance/README.md

Follow-ups requested in review (carryover from #186):
- Verify / correct any concrete endpoint paths (reload + tool invoke) vs current backend implementation.
- Fix regex engine semantics (Python regex, not ECMAScript) or avoid over-specifying.
- Verify tool names/response shapes against runtime tool dispatcher (system_skills_list, system_skill_get, etc.).

Refs: #183, #184