### PR TITLE
docs(assistance): document Skills Sheet SSOT routing (clean)

### DIFF
--- a/services/assistance/README.md
+++ b/services/assistance/README.md
@@ -13,6 +13,8 @@ The `/services/assistance/` tree is the source-of-truth for all *Assistance* app
 - Operator playbook (single source of truth): `services/assistance/docs/ACTION.md`
 - Build / deploy (single source of truth): `services/assistance/docs/BUILD.md`
 - Reminders (overview + data flow): `services/assistance/docs/REMINDERS.md`
+- Skills Sheet SSOT routing: `services/assistance/docs/SYSTEM.md`
+- Deterministic tools reference: `services/assistance/docs/TOOLS.md`
 
 ## Authoritative runtime surfaces (Jarvis)
 - Operator note:

--- a/services/assistance/docs/ACTION.md
+++ b/services/assistance/docs/ACTION.md
@@ -90,6 +90,42 @@ Doc drift policy:
   - `GET /openapi.json` (runtime API surface)
   - `services/assistance/docs/ACTION.md` (operator runbooks)
 
+## Runbook: Skills Sheet SSOT routing
+
+Background + schema: `services/assistance/docs/SYSTEM.md`.
+
+### Update the Skills Sheet
+
+- Edit rows in the sheet identified by sys_kv key `system.skills.sheet_name`.
+- Keep `name` unique.
+- Use `enabled=false` to disable without deleting.
+- Use `match_type=none` for inject-only rows.
+- Ensure `arg_json` is valid JSON when present.
+
+### Apply: system reload
+
+- Trigger a backend reload (UI: Settings → System → Reload).
+
+### Verify
+
+1) List loaded skills:
+
+```
+/tool system_skills_list {}
+```
+
+2) Fetch a specific skill:
+
+```
+/tool system_skill_get { "name": "<skill-name>" }
+```
+
+3) Compat endpoint (clients):
+
+```bash
+curl http://127.0.0.1:18018/config/voice_commands
+```
+
 ## 2-computer workflow (anti-drift mechanism)
 
 Goal:

--- a/services/assistance/docs/OVERVIEW.md
+++ b/services/assistance/docs/OVERVIEW.md
@@ -41,6 +41,7 @@ graph TD
 - Build/deploy (SSOT): `services/assistance/docs/BUILD.md`
 - System notes: `services/assistance/docs/SYSTEM.md`
 - WS protocol/tools: `services/assistance/docs/TOOLS.md`
+- Skills Sheet SSOT routing: `services/assistance/docs/SYSTEM.md`
 
 ## Conventions
 

--- a/services/assistance/docs/SYSTEM.md
+++ b/services/assistance/docs/SYSTEM.md
@@ -13,6 +13,36 @@ Notes:
 - Effective deployed base URL + operator procedures: `services/assistance/docs/ACTION.md`
 - Runtime endpoints: `GET /openapi.json`
 
+## Skills Sheet SSOT routing
+
+Jarvis can treat the **Skills Sheet** as the single source of truth (SSOT) for:
+
+- Skill routing (sheet-first dispatch)
+- System-instruction injection (inject-only rows)
+
+The active sheet is identified by sys_kv key:
+
+- `system.skills.sheet_name`
+
+Routing can be enabled/disabled by:
+
+- `system.skills.routing.enabled` (default `false`)
+
+### Skill row schema
+
+| Column | Type | Required | Description |
+|---|---:|:---:|---|
+| `name` | string | ✓ | Unique identifier for the skill (unique key) |
+| `enabled` | boolean | ✓ | `true` to activate; `false` to ignore |
+| `priority` | integer | ✓ | Lower number runs earlier (tie-break + injection order) |
+| `match_type` | enum | — | `exact`, `prefix`, `regex`, or `none` (inject-only) |
+| `pattern` | string | — | Match pattern, interpreted per `match_type` |
+| `lang` | string | — | Optional language tag (e.g. `th`, `en`) |
+| `handler` | enum | ✓ | `tool_call`, `inject`, or `passthrough` |
+| `arg_json` | JSON string | — | Optional handler args (for `tool_call`: `{ "tool": "...", "args": {...} }`) |
+
+Operator procedure (update → reload → verify): `services/assistance/docs/ACTION.md`.
+
 ## System KV keys
 
 ### `system.sheets` (required)

--- a/services/assistance/docs/TOOLS.md
+++ b/services/assistance/docs/TOOLS.md
@@ -213,6 +213,58 @@ Purpose: manage queued “pending” actions (confirmation-based writes).
 - `pending_confirm({ confirmation_id })`
 - `pending_cancel({ confirmation_id })`
 
+## Skills Sheet tools
+
+### `system_skills_list`
+
+Returns all currently loaded skill rows from the active Skills Sheet.
+
+Request:
+
+```json
+{}
+```
+
+Response (shape):
+
+```json
+{
+  "ok": true,
+  "skills": [
+    {
+      "name": "weather_lookup",
+      "enabled": true,
+      "priority": 10,
+      "match_type": "prefix",
+      "pattern": "อากาศ",
+      "lang": "th",
+      "handler": "tool_call",
+      "arg_json": {"tool": "get_weather", "args": {}}
+    }
+  ],
+  "routing_enabled": true,
+  "sheet_name": "jarvis-skills-prod"
+}
+```
+
+### `system_skill_get`
+
+Fetch a single skill row by name.
+
+Request:
+
+```json
+{ "name": "weather_lookup" }
+```
+
+Response (shape):
+
+```json
+{ "ok": true, "skill": { "name": "weather_lookup" } }
+```
+
+Operator verification flow: `services/assistance/docs/ACTION.md`.
+
 ### Tool chart: memory.*
 
 Purpose: read/write authoritative memory items in the Memory Sheet (KV5 schema: key,value,enabled,scope,priority).


### PR DESCRIPTION
Clean replacement for closed PR #197 (which targeted main).

Adds Skills Sheet SSOT routing documentation and operator procedure pointers:
- services/assistance/docs/SYSTEM.md
- services/assistance/docs/TOOLS.md
- services/assistance/docs/ACTION.md
- services/assistance/docs/OVERVIEW.md
- services/assistance/README.md

No runtime code changes.