### PR TITLE
fix(jarvis-frontend): allow current_news tools in /tool

### DIFF
--- a/services/assistance/jarvis-frontend/App.tsx
+++ b/services/assistance/jarvis-frontend/App.tsx
@@ -930,7 +930,9 @@ export default function App() {
 			const okPrefix =
 				name.startsWith("system_") ||
 				name.startsWith("pending_") ||
-				name.startsWith("macro_");
+				name.startsWith("macro_") ||
+				name.startsWith("current_news_") ||
+				name.startsWith("news_follow_");
 			if (!okPrefix) return { name, args: { __invalid_tool_prefix: true } };
 			if (!rest) return { name, args: {} };
 			try {


### PR DESCRIPTION
Fixes frontend /tool command prefix allowlist so these commands are not rejected client-side:
- current_news_*
- news_follow_*

This resolves the in-chat warning: .

No backend changes.